### PR TITLE
Porting to RHEL8 environment

### DIFF
--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -43,6 +43,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/sysmacros.h>
+
 #include "glue.h"
 #include "const.h"
 #include "inode.h"

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -35,6 +35,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/sysmacros.h>
 
 /* Definition of the file system layout: */
 #include "const.h"

--- a/src/fs.h
+++ b/src/fs.h
@@ -15,6 +15,7 @@
 
 #include <limits.h>
 #include <errno.h>
+#include <sys/sysmacros.h>
 
 #include "mfsdir.h"
 #include "const.h"


### PR DESCRIPTION
Hi,

Including sys/sysmacros.h is needed to use major()/minor()/mkdev() macros in a formal manner
I found this when I tried to compile this program in RHEL8 environment.
I wrote a simple patch to fix this issue.
I could not determine whether this patch would be acceptable for your design.
In particular, I added "include <sys/sysmacros.h>" line into fsck/fsck.c, mkfs/mkfs.c, and src/fs.h, however you might regard this modification as incorrect.
Would you please merge this patch if this patch is correct?
